### PR TITLE
Add missing decorator tests.

### DIFF
--- a/test/decorators/AbstractTest.jsx
+++ b/test/decorators/AbstractTest.jsx
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+
+describe('@Abstract decorator', () => {
+
+    it('sanity check', () => {
+        class AbstractClass {
+            @Abstract foo() { }
+        }
+        class ConcreteClass extends AbstractClass {
+            foo() {
+            }
+        }
+
+        assert.throws(() => {
+            new AbstractClass().foo();
+        }, /Abstract method foo called on AbstractClass/);
+
+        assert.doesNotThrow(() => {
+            new ConcreteClass().foo();
+        });
+    });
+
+});

--- a/test/decorators/BindTest.jsx
+++ b/test/decorators/BindTest.jsx
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+
+describe('@Bind decorator', () => {
+
+    it('sanity check', () => {
+        class C {
+            x = 1;
+            @Bind
+            bound() {
+                return this.x;
+            }
+        }
+
+        let c = new C();
+        assert.equal((0, c.bound)(), 1);
+    });
+
+});

--- a/test/decorators/CacheTest.jsx
+++ b/test/decorators/CacheTest.jsx
@@ -14,9 +14,6 @@
 /* global it, describe */
 
 import assert from 'assert';
-import sinon from 'sinon';
-
-import { TaskQueue, Binder } from '../../index';
 
 describe('@Cache decorator', () => {
 

--- a/test/decorators/DebounceTest.jsx
+++ b/test/decorators/DebounceTest.jsx
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+
+describe('@Debounce decorator', () => {
+
+    it('sanity check', () => {
+        let called = 0;
+
+        class C {
+            @Debounce(100)
+            method() {
+                called++;
+            }
+        }
+
+        let c = new C();
+        c.method();
+        c.method();
+        c.method();
+
+        assert.equal(called, 0);
+    });
+
+});

--- a/test/decorators/DelayTest.jsx
+++ b/test/decorators/DelayTest.jsx
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+import sinon from 'sinon';
+
+describe('@Delay decorator', () => {
+
+    it('sanity check', () => {
+        const clock = sinon.useFakeTimers();
+        try {
+            let spy = sinon.spy();
+            class C {
+                @Delay(1000)
+                foo() {
+                    spy();
+                }
+            }
+
+            let c = new C();
+            c.foo();
+            assert(spy.notCalled, 'not called delayed function yet');
+            clock.tick(1000);
+            assert(spy.called, 'called delayed function');
+        }
+        finally {
+            clock.restore();
+        }
+    });
+
+
+});

--- a/test/decorators/MemoizeTest.jsx
+++ b/test/decorators/MemoizeTest.jsx
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+
+describe('@Memoize decorator', () => {
+
+    it('sanity check', () => {
+        let i = 0;
+        class C {
+            @Memoize
+            static get foo() {
+                return ++i;
+            }
+        }
+
+        C.foo;
+        C.foo;
+        C.foo;
+        assert.equal(C.foo, 1);
+    });
+
+});

--- a/test/decorators/ObservableTest.jsx
+++ b/test/decorators/ObservableTest.jsx
@@ -1,0 +1,142 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+import { Binder, Signal, TaskQueue } from '../../index';
+
+describe('Observable Decorator', () => {
+
+    it('default value', () => {
+        class Data {
+            @Observable value = 'default value';
+        }
+
+        let data = new Data;
+        assert.equal(data.value, 'default value');
+    });
+
+    it('inherited default value', () => {
+        class Base {
+            @Observable value = 'default value';
+        }
+
+        class Subclass extends Base {
+            @Observable value;
+        }
+
+        let data1 = new Base;
+        let data2 = new Subclass;
+
+        assert.equal(data1.value, 'default value');
+        assert.equal(data2.value, 'default value');
+    });
+
+    it('replace default value', () => {
+        class Base {
+            @Observable value = 'default value';
+        }
+
+        class Subclass extends Base {
+            @Observable value = 'subclass default value';
+        }
+
+        let data1 = new Base;
+        let data2 = new Subclass;
+
+        assert.equal(data1.value, 'default value');
+        assert.equal(data2.value, 'subclass default value');
+    });
+
+    it('check for events', () => {
+        class Data {
+            @Observable value = 'default value';
+        }
+
+        let data = new Data;
+
+        let changed = false;
+        Signal.on(data, 'value', () => changed = true);
+        data.value = 'changed value';
+
+        assert(changed, 'value change event was triggered');
+        assert.equal(data.value, 'changed value');
+    });
+
+    it('check for inherited classes events', () => {
+        class Base {
+            @Observable value = 'default value';
+        }
+
+        class Subclass extends Base {
+            @Observable value;
+        }
+
+        let data = new Subclass;
+
+        let changed = false;
+        Signal.on(data, 'value', () => changed = true);
+        data.value = 'changed value';
+
+        assert(changed, 'value change event was triggered');
+        assert.equal(data.value, 'changed value');
+    });
+
+    it('triggers an update when changed asynchronously', done => {
+        let nCalls = 0;
+
+        class Data {
+            @Observable value = 'default value';
+        }
+
+        let data = new Data;
+        let binder;
+
+        let onDone = error => {
+            binder.dispose();
+            done(error);
+        };
+
+        binder = new Binder(
+            () => 'my value is ' + data.value,
+            value => {
+                nCalls = nCalls + 1;
+                if (nCalls === 1) {
+                    if (value !== 'my value is default value') {
+                        return onDone(new Error('Initial call had incorrect response: ' + value));
+                    }
+                }
+                else if (nCalls === 2) {
+                    if (value === 'my value is updated value') {
+                        return onDone();
+                    }
+                    else {
+                        return onDone(new Error('Second call had incorrect response: ' + value));
+                    }
+                }
+                else {
+                    return onDone(new Error('Too many calls to binder update func.'));
+                }
+            });
+
+        TaskQueue.run();
+
+        setTimeout(
+            () => {
+                data.value = 'updated value';
+                TaskQueue.run();
+            }, 0);
+    });
+
+});

--- a/test/decorators/PrototypeTest.jsx
+++ b/test/decorators/PrototypeTest.jsx
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+
+describe('@Prototype decorator', () => {
+
+    it('sanity check', () => {
+        @Prototype({ x: 1, y: 2 })
+        class C {
+        }
+
+        assert.equal(C.prototype.x, 1);
+        assert.equal(C.prototype.y, 2);
+    });
+
+});

--- a/test/decorators/TaskTest.jsx
+++ b/test/decorators/TaskTest.jsx
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+import sinon from 'sinon';
+import rAF from '../../src/internal/queue/rAF';
+
+describe('@Task decorator', () => {
+
+    it('sanity check', () => {
+        let spy = sinon.spy();
+        class C {
+            @Task
+            foo() {
+                spy();
+            }
+        }
+
+        let c = new C();
+        c.foo();
+        assert(spy.notCalled);
+        rAF.tick();
+        assert(spy.called);
+    });
+
+});

--- a/test/decorators/ThrottleTest.jsx
+++ b/test/decorators/ThrottleTest.jsx
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+
+describe('@Throttle decorator', () => {
+
+    it('sanity check', () => {
+
+        let called = 0;
+
+        class C {
+            @Throttle(100)
+            method() {
+                called++;
+            }
+        }
+
+        let c = new C();
+        c.method();
+        c.method();
+        c.method();
+
+        assert.equal(called, 1);
+    });
+
+});


### PR DESCRIPTION
The new tests have been extracted from my decorators-legacy branch, as well as the `Task` and `Wrap` decorators, which were still using the old decorator wrappers.