### PR TITLE
Add remaining relevant tests.

### DIFF
--- a/test/DisposableTest.jsx
+++ b/test/DisposableTest.jsx
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import { Disposable } from '../index';
+import assert from 'assert';
+import sinon from 'sinon';
+
+describe('Utils.Disposable', () => {
+
+    it('disposes children', () => {
+        let parent = new Disposable();
+        let child = new Disposable();
+        parent.link(child);
+
+        let spy = sinon.spy(child, 'dispose');
+        parent.dispose();
+        assert(spy.calledOnce, 'child dispose should be called');
+    });
+
+    it('unlink', () => {
+        let parent = new Disposable();
+        let child = new Disposable();
+        parent.link(child);
+        parent.unlink(child);
+        let spy = sinon.spy(child, 'dispose');
+        parent.dispose();
+        assert(spy.notCalled, 'child dispose should not be called');
+    });
+
+    it('unlink when no disposables exist (should not throw)', () => {
+        let parent = new Disposable();
+        parent.unlink(null);
+        parent.unlink(new Disposable());
+    });
+
+    it('set disposables, but then try to unlink a non-child', () => {
+        let parent = new Disposable();
+        parent.link(new Disposable());
+        parent.unlink(new Disposable());
+    });
+
+    it('disposes a function', () => {
+        let parent = new Disposable();
+        let childFn = sinon.spy();
+        parent.link(childFn);
+        parent.disposeLink(childFn);
+        assert(childFn.calledOnce, 'child disposed should be called');
+    });
+
+    it('disposeLink', () => {
+        let parent = new Disposable();
+        let child = new Disposable();
+        parent.link(child);
+        let spy = sinon.spy(child, 'dispose');
+        parent.disposeLink(child);
+        assert(spy.calledOnce, 'child dispose should be called');
+    });
+
+    it('tree of disposables', () => {
+        let grandparent = new Disposable();
+        let parent = new Disposable();
+        let child = new Disposable();
+        grandparent.link(parent);
+        parent.link(child);
+
+        let parentSpy = sinon.spy(parent, 'dispose');
+        let childSpy = sinon.spy(child, 'dispose');
+        grandparent.dispose();
+        assert(parentSpy.calledOnce, 'parent dispose should be called');
+        assert(childSpy.calledOnce, 'child dispose should be called');
+    });
+
+});

--- a/test/ObservableArrayTest.jsx
+++ b/test/ObservableArrayTest.jsx
@@ -1,0 +1,240 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+import { ObservableArray, Binder, TaskQueue } from '../index';
+
+describe('Utils.ObservableArray', () => {
+
+    it('updates to ObservableArray by mutators should invalidate jsx', () => {
+        let arr = new ObservableArray([ 'first item' ]);
+
+        let test = new Binder(() => arr.at(0));
+
+        assert.equal(test.previousValue, 'first item');
+
+        arr.unshift('second item');
+        TaskQueue.run();
+
+        assert.equal(test.previousValue, 'second item');
+
+        test.dispose();
+    });
+
+    it('setAt() changes value and signals the change', () => {
+        let arr = new ObservableArray([ 'first item', 'second item' ]);
+
+        let test = new Binder(() => arr.at(1));
+
+        assert.equal(test.previousValue, 'second item');
+
+        arr.setAt(1, 'changed item');
+        TaskQueue.run();
+
+        assert.equal(test.previousValue, 'changed item');
+
+        test.dispose();
+    });
+
+    it('round trips active arrays to native arrays and back', () => {
+        let arr = new ObservableArray([ 'first item', 'second item' ]);
+        let arr2 = new ObservableArray(arr.toArray());
+
+        let test = new Binder(() => arr2.at(0));
+
+        assert.equal(test.previousValue, 'first item');
+
+        test.dispose();
+    });
+
+    it('resizing array to same size has no effect', () => {
+        let arr = new ObservableArray([ 'first item', 'second item' ]);
+
+        let test = new Binder(() => arr.at(1));
+
+        assert.equal(test.previousValue, 'second item');
+
+        arr.length = 2;
+        TaskQueue.run();
+
+        assert.equal(test.previousValue, 'second item');
+
+        test.dispose();
+    });
+
+    it('resizing array to larger size does not affect previous bindings', () => {
+        let arr = new ObservableArray([ 'first item' ]);
+
+        let test1 = new Binder(() => arr.at(0));
+        let test2 = new Binder(() => arr.at(1));
+
+        assert.equal(test1.previousValue, 'first item');
+        assert.equal(test2.previousValue, undefined);
+
+        arr.length = 2;
+        TaskQueue.run();
+
+        assert.equal(test1.previousValue, 'first item');
+        assert.equal(test2.previousValue, undefined);
+
+        test1.dispose();
+        test2.dispose();
+    });
+
+    it('resizing array to smaller size changes bindings to truncated values', () => {
+        let arr = new ObservableArray([ 'first item', 'second item' ]);
+
+        let test1 = new Binder(() => arr.at(0));
+        let test2 = new Binder(() => arr.at(1));
+
+        assert.equal(test1.previousValue, 'first item');
+        assert.equal(test2.previousValue, 'second item');
+
+        arr.length = 1;
+        TaskQueue.run();
+
+        assert.equal(test1.previousValue, 'first item');
+        assert.equal(test2.previousValue, undefined);
+
+        test1.dispose();
+        test2.dispose();
+    });
+
+    it('swapped values affect bindings', () => {
+        let arr = new ObservableArray([ 'first item', 'second item' ]);
+
+        let test1 = new Binder(() => arr.at(0));
+        let test2 = new Binder(() => arr.at(1));
+
+        assert.equal(test1.previousValue, 'first item');
+        assert.equal(test2.previousValue, 'second item');
+
+        arr.swapItems([ 'swapped value' ]);
+        TaskQueue.run();
+
+        assert.equal(test1.previousValue, 'swapped value');
+        assert.equal(test2.previousValue, undefined);
+
+        test1.dispose();
+        test2.dispose();
+    });
+
+    it('removeItem deletes one item and updates bindings', () => {
+        let arr = new ObservableArray([ 'one', 'two', 'three', 'two' ]);
+
+        let test1 = new Binder(() => arr.at(0));
+        let test2 = new Binder(() => arr.at(1));
+
+        assert.equal(test1.previousValue, 'one');
+        assert.equal(test2.previousValue, 'two');
+
+        arr.removeItem('two');
+        assert.equal(arr.length, 3);
+
+        TaskQueue.run();
+
+        assert.equal(test1.previousValue, 'one');
+        assert.equal(test2.previousValue, 'three');
+
+        test1.dispose();
+        test2.dispose();
+    });
+
+    it('overrides Array.prototype.concat properly', () => {
+        let a = new ObservableArray([ 1, 2, 3 ]);
+        let b = new ObservableArray([ 4, 5, 6 ]);
+        let c = new ObservableArray([ 7, 8 ]);
+        let d = [ 9 ];
+        assert.deepEqual(a.concat(b, c, d).toArray(), [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
+        assert.deepEqual(a.concatToArray(b, c, d), [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
+
+        let test = new Binder(() => a.concat(b, c).join(''));
+        assert.equal(test.previousValue, '12345678');
+        TaskQueue.run();
+
+        a.unshift('.');
+        b.unshift('.');
+        c.unshift('.');
+        TaskQueue.run();
+        assert.equal(test.previousValue, '.123.456.78');
+
+        test.dispose();
+    });
+
+    it('overrides Array methods which return a new instance of array properly', () => {
+        let a = new ObservableArray([ 'a', 'b', 'c' ]);
+
+        // Map
+        assert.deepEqual(a.map(v => v + '!').toArray(), [ 'a!', 'b!', 'c!' ]);
+        assert.deepEqual(a.mapToArray(v => v + '!'), [ 'a!', 'b!', 'c!' ]);
+        // Slice
+        assert.deepEqual(a.slice().toArray(), [ 'a', 'b', 'c' ]);
+        assert.deepEqual(a.slice(1,2).toArray(), [ 'b' ]);
+        assert.deepEqual(a.sliceToArray(), [ 'a', 'b', 'c' ]);
+        assert.deepEqual(a.sliceToArray(1,2), [ 'b' ]);
+        // Filter
+        assert.deepEqual(a.filter(v => v !== 'a').toArray(), [ 'b', 'c' ]);
+        assert.deepEqual(a.filterToArray(v => v !== 'a'), [ 'b', 'c' ]);
+
+        let test = new Binder(() =>
+            a.filter(v => v !== 'a')
+                .map(v => v + '!')
+                .slice(0,2).join('')
+        );
+
+        assert.equal(test.previousValue, 'b!c!');
+        TaskQueue.run();
+
+        a.unshift('o');
+        TaskQueue.run();
+        assert.equal(test.previousValue, 'o!b!');
+
+        test.dispose();
+    });
+
+    it('overrides Array mutators returning array properly', () => {
+        let a = new ObservableArray([ 3, 2, 1 ]);
+        let b = a.sort();
+        assert.deepEqual(a.toArray(), [ 1, 2, 3 ]);
+        assert.equal(a, b);
+
+        let c = a.fill('a');
+        assert.deepEqual(c.toArray(), [ 'a', 'a', 'a' ]);
+        assert.equal(a, c);
+
+        a.push('c'); // a a a c
+        let test = new Binder(() =>  a.copyWithin(0, 3).join(''));
+        assert.equal(test.previousValue, 'caac');
+
+        a.fill('o');
+        TaskQueue.run();
+        assert.equal(test.previousValue, 'oooo');
+
+        test.dispose();
+    });
+
+    it('toArray() triggers bindings', () => {
+        let arr = new ObservableArray([ 'a', 'b' ]);
+        let test = new Binder(() => arr.toArray().join(''));
+        assert.equal(test.previousValue, 'ab');
+
+        arr.push('c');
+        TaskQueue.run();
+        assert.equal(test.previousValue, 'abc');
+
+        test.dispose();
+    });
+
+});

--- a/test/ObservableMapTest.jsx
+++ b/test/ObservableMapTest.jsx
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+import { ObservableMap, Binder, TaskQueue } from '../index';
+
+describe('Utils.ObservableMap', () => {
+
+    it('can create an empty ObservableMap and modify it', () => {
+        let map = new ObservableMap;
+
+        assert.equal(map.size, 0);
+        assert.equal(map.has('key1'), false, 'key1 should not be in an empty map');
+
+        let newMap = map.set('key1', 'value1');
+        assert.equal(newMap, map, 'ObservableMap.set should return the map');
+
+        assert.equal(map.size, 1);
+        assert.equal(map.has('key1'), true, 'key1 should now be in the map');
+        assert.equal(map.get('key1'), 'value1');
+    });
+
+    it('can create an ObservableMap out of non-map data', () => {
+        let map = new ObservableMap({ 'key1': 'value1', 'key2': 'value2' });
+
+        assert.equal(map.size, 2);
+        assert.equal(map.get('key1'), 'value1');
+    });
+
+    it('can create an ObservableMap out of an array-constructed Map', () => {
+        let map = new ObservableMap(new Map([ [ 'key1', 'value1' ], [ 'key2', 'value2' ] ]));
+
+        assert.equal(map.size, 2);
+        assert.equal(map.get('key1'), 'value1');
+    });
+
+    it('can delete elements from an observable map', () => {
+        let map = new ObservableMap({ 'key1': 'value1', 'key2': 'value2' });
+        assert.equal(map.size, 2);
+
+        let success = map.delete('key1');
+        assert.equal(success, true, 'Should be able to successfully delete an existing key');
+        assert.equal(map.size, 1, 'Map should be reduced in size after deleting');
+        assert.equal(map.get('key1'), undefined, 'Accessing a key that doesn\'t exist should return undefined');
+
+        success = map.delete('key_unknown');
+        assert.equal(success, false, 'delete() should return false if key is not present');
+        assert.equal(map.size, 1, 'delete() of an undefined key should not affect the map size');
+    });
+
+    it('can clear an observable map', () => {
+        let map = new ObservableMap({ 'key1': 'value1', 'key2': 'value2' });
+        assert.equal(map.size, 2);
+
+        let result = map.clear();
+        assert.equal(result, undefined, 'clear() should return undefined');
+        assert.equal(map.size, 0, 'Map should no longer have any keys after clearing');
+    });
+
+    it('swapped values affect bindings', () => {
+        let map = new ObservableMap({ a: 'first item', b: 'second item' });
+
+        let test1 = new Binder(() => map.get('a'));
+        let test2 = new Binder(() => map.get('b'));
+        let test3 = new Binder(() => map.size);
+
+        assert.equal(test1.previousValue, 'first item');
+        assert.equal(test2.previousValue, 'second item');
+        assert.equal(test3.previousValue, 2);
+
+        map.swapItems({ a: 'first new item' });
+        TaskQueue.run();
+
+        assert.equal(test1.previousValue, 'first new item');
+        assert.equal(test2.previousValue, undefined);
+        assert.equal(test3.previousValue, 1);
+
+        test1.dispose();
+        test2.dispose();
+        test3.dispose();
+    });
+
+});

--- a/test/ObservableSetTest.jsx
+++ b/test/ObservableSetTest.jsx
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import assert from 'assert';
+import { ObservableSet, Binder, TaskQueue } from '../index';
+
+describe('Utils.ObservableSet', () => {
+
+    it('can create an empty ObservableSet and modify it', () => {
+        let set = new ObservableSet;
+
+        assert.equal(set.size, 0);
+
+        set.add('value');
+        set.add('value');
+
+        assert.equal(set.size, 1);
+        assert.equal(set.has('value'), true);
+    });
+
+    it('can create an ObservableSet out of an iterable object', () => {
+        let map = new Map([ [ 'key1', 'value1' ], [ 'key2', 'value2' ] ]);
+        let set = new ObservableSet(map.values());
+
+        assert.equal(set.size, 2);
+        assert.equal(set.has('value1'), true);
+    });
+
+    it('can create an ObservableSet out of an array-constructed Set', () => {
+        let set = new ObservableSet(new Set([ 'value1', 'value2' ]));
+
+        assert.equal(set.size, 2);
+        assert.equal(set.has('value1'), true);
+    });
+
+    it('swapped values affect bindings', () => {
+        let set = new ObservableSet([ 'first item', 'second item' ]);
+
+        let test1 = new Binder(() => set.has('first item'));
+        let test2 = new Binder(() => set.has('second item'));
+        let test3 = new Binder(() => set.size);
+
+        assert.equal(test1.previousValue, true);
+        assert.equal(test2.previousValue, true);
+        assert.equal(test3.previousValue, 2);
+
+        set.swapItems([ 'second item' ]);
+        TaskQueue.run();
+
+        assert.equal(test1.previousValue, false);
+        assert.equal(test2.previousValue, true);
+        assert.equal(test3.previousValue, 1);
+
+        test1.dispose();
+        test2.dispose();
+        test3.dispose();
+    });
+
+});

--- a/test/ScopeTest.jsx
+++ b/test/ScopeTest.jsx
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import { Scope } from '../index';
+import assert from 'assert';
+
+describe('JSX.Scope', () => {
+
+    it('should be able to create a scope', () => {
+        let scope = new Scope();
+        scope.defineObservable('myValue', 1);
+
+        assert.equal(scope.myValue, 1, 'Reading bindable value from scope');
+    });
+
+    it('should be able to create a nested scope', () => {
+        let parentScope = new Scope();
+        parentScope.defineObservable('myValue', 1);
+
+        let nestedScope = parentScope.fork();
+
+        assert.equal(parentScope.myValue, 1, 'Reading bindable value from parent scope');
+        assert.equal(nestedScope.myValue, 1, 'Reading bindable value from nested scope');
+
+        parentScope.myValue = 2;
+
+        assert.equal(parentScope.myValue, 2, 'Reading bindable value from parent scope after change on parent scope');
+        assert.equal(nestedScope.myValue, 2, 'Reading bindable value from nested scope after change on parent scope');
+
+        nestedScope.myValue = 3;
+
+        assert.equal(parentScope.myValue, 3, 'Reading bindable value from parent scope after change on nested scope');
+        assert.equal(nestedScope.myValue, 3, 'Reading bindable value from nested scope after change on nested scope');
+    });
+
+    it('should be able to clean a scope', () => {
+        let scope = new Scope();
+        scope.myValue = 1;
+
+        assert.equal(scope.myValue, 1, 'Reading own property value from scope');
+
+        scope.clean();
+
+        assert.equal(scope.myValue, undefined, 'Own property value should be deleted after scope.clean');
+    });
+
+});

--- a/test/SignalDispatcherTest.jsx
+++ b/test/SignalDispatcherTest.jsx
@@ -1,0 +1,272 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import { ObservableArray, SignalDispatcher, TaskQueue } from '../index';
+import assert from 'assert';
+import sinon from 'sinon';
+
+class Data {
+    @Observable x = 1;
+    @Observable y = 2;
+}
+
+describe('Utils.SignalDispatcher', () => {
+
+    it('call watch() on an observable', () => {
+        let data = new Data;
+        let dispatcher = new SignalDispatcher();
+        let callback = sinon.spy();
+
+        dispatcher.watch(() => data.x, callback);
+        dispatcher.watch(() => data.x); // should work with a noop
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 1);
+
+        // Changing to different value should trigger watch
+        data.x = 2;
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 2);
+        assert.equal(callback.getCall(1).args[0], 2);
+
+        // Changing to same value should not trigger watch
+        data.x = 2;
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 2);
+    });
+
+    it('call watch() on an observable - ignore first run', () => {
+        let data = new Data;
+        let dispatcher = new SignalDispatcher();
+        let callback = sinon.spy();
+
+        dispatcher.watch(() => data.x, callback, true);
+
+        assert.equal(callback.callCount, 0);
+
+        // Changing to different value should trigger watch
+        data.x = 2;
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 2);
+    });
+
+    it('call watchCollection() on an observable array', () => {
+        let data = new ObservableArray;
+        let dispatcher = new SignalDispatcher();
+        let callback = sinon.spy();
+
+        dispatcher.watchCollection(() => data, callback);
+        dispatcher.watchCollection(() => data); // should work with a noop
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], data.base); // TODO: Why do we pass the base here, doesn't make sense...
+
+        // Changing the array should trigger watch
+        data.push(2);
+        data.push(3);
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 2);
+        assert.equal(callback.getCall(1).args[0], data.base);
+
+        // Watch shouldn't trigger if nothing really changed
+        data.length = data.length;
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 2);
+    });
+
+    it('call watchCollection() on an observable array - ignore first run', () => {
+        let data = new ObservableArray;
+        let dispatcher = new SignalDispatcher();
+        let callback = sinon.spy();
+
+        dispatcher.watchCollection(() => data, callback, true);
+
+        assert.equal(callback.callCount, 0);
+
+        // Changing the array should trigger watch
+        data.push(2);
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], data.base);
+    });
+
+    it('watches should not trigger after disposing watch', () => {
+        let data = new Data;
+        let dispatcher = new SignalDispatcher();
+        let callback = sinon.spy();
+
+        let watch = dispatcher.watch(() => data.x, callback);
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 1);
+
+        // Changing to different value should trigger watch
+        watch.dispose();
+        data.x = 2;
+        TaskQueue.run();
+
+        // Not triggered
+        assert.equal(callback.callCount, 1);
+    });
+
+    it('watches should not trigger after disposing signal dispatcher', () => {
+        let data = new Data;
+        let dispatcher = new SignalDispatcher();
+        let callback = sinon.spy();
+
+        dispatcher.watch(() => data.x, callback);
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 1);
+
+        // Changing to different value should trigger watch
+        dispatcher.dispose();
+        data.x = 2;
+        TaskQueue.run();
+
+        // Not triggered
+        assert.equal(callback.callCount, 1);
+    });
+
+    it('should be able define an observable and watch it', () => {
+        let dispatcher = new SignalDispatcher();
+        dispatcher.defineObservable('x', 2);
+        let callback = sinon.spy();
+
+        dispatcher.watch(() => dispatcher.x, callback);
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 2);
+
+        // Changing to different value should trigger watch
+        dispatcher.x = 4;
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 2);
+        assert.equal(callback.getCall(1).args[0], 4);
+
+        // Changing to the same value should not trigger watch
+        dispatcher.x = 4;
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 2);
+
+        // Defining an observable again should just update its value
+        dispatcher.defineObservable('x', 10);
+        TaskQueue.run();
+
+        assert.equal(dispatcher.x, 10);
+        assert.equal(callback.callCount, 3);
+        assert.equal(callback.getCall(2).args[0], 10);
+    });
+
+    it('should be able to trigger an event and listen for it with on/off', () => {
+        let dispatcher = new SignalDispatcher();
+        dispatcher.trigger('event'); // Triggering an event shouldn't do anything, if no listeners
+        let callback = sinon.spy();
+        dispatcher.on('event', callback);
+
+        assert.equal(callback.callCount, 0);
+
+        // Trigger an event should call listener
+        dispatcher.trigger('event', 'arg1', 'arg2');
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 'arg1');
+        assert.equal(callback.getCall(0).args[1], 'arg2');
+
+        // Trigger a different event should not call listener
+        dispatcher.trigger('another_event', 'arg1', 'arg2');
+
+        assert.equal(callback.callCount, 1);
+
+        // Stop listening, listener should no longer be called
+        dispatcher.off('event', callback);
+        dispatcher.trigger('event', 'arg1', 'arg2');
+
+        assert.equal(callback.callCount, 1);
+
+        // Calling off again should have no effect
+        dispatcher.off('event', callback);
+    });
+
+    it('should be able to trigger an event and listen for it with listenTo/stopListening', () => {
+        let dispatcher = new SignalDispatcher();
+        let listener = new SignalDispatcher();
+
+        let callback = sinon.spy();
+        listener.listenTo(dispatcher, 'event', callback);
+
+        assert.equal(callback.callCount, 0);
+
+        // Trigger an event should call listener
+        dispatcher.trigger('event', 'arg1', 'arg2');
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 'arg1');
+        assert.equal(callback.getCall(0).args[1], 'arg2');
+
+        // Trigger a different event should not call listener
+        dispatcher.trigger('another_event', 'arg1', 'arg2');
+
+        assert.equal(callback.callCount, 1);
+
+        // Trigger event on a different object should not call listener
+        listener.trigger('event', 'arg1', 'arg2');
+
+        assert.equal(callback.callCount, 1);
+
+        // Stop listening, listener should no longer be called
+        listener.stopListening(dispatcher, 'event', callback);
+        dispatcher.trigger('event', 'arg1', 'arg2');
+
+        assert.equal(callback.callCount, 1);
+
+        // Calling stopListening again should have no effect
+        listener.stopListening(dispatcher, 'event', callback);
+    });
+
+    it('dispose should call stopListening', () => {
+        let dispatcher = new SignalDispatcher();
+        let listener = new SignalDispatcher();
+
+        let callback = sinon.spy();
+        listener.listenTo(dispatcher, 'event', callback);
+
+        assert.equal(callback.callCount, 0);
+
+        // Trigger an event should call listener
+        dispatcher.trigger('event', 'arg1', 'arg2');
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 'arg1');
+        assert.equal(callback.getCall(0).args[1], 'arg2');
+
+        // Dispose should remove listener
+        listener.dispose();
+
+        dispatcher.trigger('event', 'arg1', 'arg2');
+
+        assert.equal(callback.callCount, 1);
+    });
+
+});

--- a/test/bindings/BinderTest.jsx
+++ b/test/bindings/BinderTest.jsx
@@ -1,0 +1,320 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import { Binder, TaskQueue } from '../../index';
+import assert from 'assert';
+import sinon from 'sinon';
+
+describe('Bindings.Binder', () => {
+
+    it('detect property change - bind to function', () => {
+        class X {
+            @Observable data;
+        }
+        let x = new X;
+        x.data = 'first value';
+
+        let callback = sinon.spy();
+        new Binder(() => x.data, callback);
+
+        assert.equal(callback.callCount, 1, 'The binder callback should trigger.');
+        assert.equal(callback.getCall(0).args[0], 'first value');
+
+        x.data = 'second value';
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 2, 'The binder callback should trigger a second time after we push a new item.');
+        assert.equal(callback.getCall(1).args[0], 'second value');
+    });
+
+    it('detect property change - bind to getter/setter', () => {
+        class X {
+            @Observable data;
+        }
+        let x = new X;
+        x.data = 'first value';
+
+        let callback = sinon.spy();
+        new Binder({
+            get() {
+                return x.data;
+            },
+            set(v) {
+                x.data = v;
+            }
+        }, callback);
+
+        assert.equal(callback.callCount, 1, 'The binder callback should trigger.');
+        assert.equal(callback.getCall(0).args[0], 'first value');
+
+        x.data = 'second value';
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 2, 'The binder callback should trigger a second time after we push a new item.');
+        assert.equal(callback.getCall(1).args[0], 'second value');
+    });
+
+    it('detect property change - without first run', () => {
+        class X {
+            @Observable data;
+        }
+
+        let x = new X;
+        x.data = 'first value';
+
+        let callback = sinon.spy();
+        new Binder(() => x.data, callback, true);
+
+        assert.equal(callback.callCount, 0, 'The binder callback should not trigger the first time.');
+
+        x.data = 'second value';
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 1, 'The binder callback should trigger the first time time after we push a new item.');
+        assert.equal(callback.getCall(0).args[0], 'second value');
+    });
+
+    it('previous bindings should be disposed when a value changes', () => {
+        let unobservable = 1;
+
+        class X {
+            @Observable condition = true;
+            @Observable value1 = 'true';
+            @Observable value2 = 'false';
+        }
+        let x = new X;
+
+        let callback = sinon.spy();
+        new Binder(() => x.condition ? x.value1 : (x.value2 + unobservable), callback);
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 'true');
+
+        x.condition = false;
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 2);
+        assert.equal(callback.getCall(1).args[0], 'false1');
+
+        x.value1 = 'very true';
+        unobservable = 2;
+        TaskQueue.run();
+
+        // Since we only changed an observable in the if-clause, and an unobservable value,
+        // this should NOT cause the watch to trigger. If it does, that indicates the previous
+        // binders not being removed.
+        assert.equal(callback.callCount, 2);
+    });
+
+    it('previous bindings should be disposed when a value changes', () => {
+        let unobservable = 1;
+
+        class X {
+            @Observable condition = true;
+            @Observable value1 = 'true';
+            @Observable value2 = 'false';
+        }
+        let x = new X;
+
+        let callback = sinon.spy();
+        new Binder(() => x.condition ? x.value1 : (x.value2 + unobservable), callback);
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 'true');
+
+        x.condition = false;
+        TaskQueue.run();
+
+        assert.equal(callback.callCount, 2);
+        assert.equal(callback.getCall(1).args[0], 'false1');
+
+        x.value1 = 'very true';
+        unobservable = 2;
+        TaskQueue.run();
+
+        // Since we only changed an observable in the if-clause, and an unobservable value,
+        // this should NOT cause the watch to trigger. If it does, that indicates the previous
+        // binders not being removed.
+        assert.equal(callback.callCount, 2);
+    });
+
+    it('binding to a promise - external to watch', () => {
+
+        let resolver;
+        let p = new Promise(resolve => resolver = resolve);
+
+        let callback = sinon.spy();
+        new Binder(() => p, callback);
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], undefined);
+
+        resolver(10);
+        TaskQueue.run();
+
+        // TODO: Binding to promise doesn't work right now - expect it to resolve
+        assert.equal(callback.callCount, 1);
+        // assert.equal(callback.getCall(1).args[0], 10);
+    });
+
+    it('binding to a promise - constructed inside watch', () => {
+
+        let callback = sinon.spy();
+        new Binder(() => Promise.resolve(10), callback);
+
+        // TODO: Binding to promise doesn't work right now - expect it to resolve
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], undefined);
+    });
+
+    it('mutation within a binder', () => {
+        class X {
+            @Observable value = 0;
+        }
+        let x = new X;
+
+        let callback = sinon.spy();
+        new Binder(() => x.value++, callback);
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 0);
+        assert.equal(x.value, 1);
+
+        // Should not continue to update value
+        TaskQueue.run();
+        assert.equal(callback.callCount, 1);
+        assert.equal(x.value, 1);
+
+        x.value = 10;
+        TaskQueue.run();
+        assert.equal(callback.callCount, 2);
+        assert.equal(callback.getCall(1).args[0], 10);
+        assert.equal(x.value, 11);
+
+        // Should not continue to update value
+        TaskQueue.run();
+        assert.equal(callback.callCount, 2);
+        assert.equal(x.value, 11);
+    });
+
+    it('mutation within a binder - no invalidate', () => {
+        class X {
+            @Observable value = 0;
+        }
+        let x = new X;
+
+        let callback = sinon.spy();
+        new Binder(() => x.value++, callback, false, null);
+
+        assert.equal(callback.callCount, 1);
+        assert.equal(callback.getCall(0).args[0], 0);
+        assert.equal(x.value, 1);
+
+        // Should not continue to update value
+        TaskQueue.run();
+        assert.equal(callback.callCount, 1);
+        assert.equal(x.value, 1);
+
+        x.value = 10;
+        TaskQueue.run();
+        assert.equal(callback.callCount, 2);
+        assert.equal(callback.getCall(1).args[0], 10);
+        assert.equal(x.value, 11);
+
+        // Should not continue to update value
+        TaskQueue.run();
+        assert.equal(callback.callCount, 2);
+        assert.equal(x.value, 11);
+    });
+
+    it('binder without callback should not crash', () => {
+        class X {
+            @Observable data;
+        }
+        let x = new X;
+
+        new Binder();
+        new Binder(() => x.data);
+        new Binder(() => x.data, null);
+
+        x.data = 'second value';
+        TaskQueue.run();
+        // No crash
+    });
+
+    it('cannot pop with no mutators', () => {
+        sinon.spy(console, 'error');
+
+        Binder.popMutator();
+        assert.equal(console.error.getCall(0).args[0], 'Trying to pop a mutator that is not in the top of the stack');
+
+        let mutator = {};
+        Binder.pushMutator(mutator);
+        Binder.popMutator({});
+        assert.equal(console.error.getCall(1).args[0], 'Trying to pop a mutator that is not in the top of the stack');
+
+        Binder.popMutator(mutator);
+        assert.equal(console.error.callCount, 2);
+        console.error.restore();
+    });
+
+    it('can push and pop mutators', () => {
+        class X {
+            @Observable data = 'first';
+        }
+        let x = new X;
+
+        let mutator1 = {
+            record: sinon.spy()
+        };
+
+        let mutator2 = {
+            record: sinon.spy()
+        };
+
+        Binder.pushMutator(mutator1);
+
+        x.data = 'second';
+        assert.equal(mutator1.record.callCount, 1);
+        assert.equal(mutator1.record.getCall(0).args[0], x);
+        assert.equal(mutator1.record.getCall(0).args[1], 'data');
+        assert.equal(mutator1.record.getCall(0).args[2], 'second');
+        assert.equal(mutator1.record.getCall(0).args[3], 'first');
+
+        Binder.pushMutator(mutator2);
+        x.data = 'third';
+        assert.equal(mutator1.record.callCount, 1);
+        assert.equal(mutator2.record.callCount, 1);
+        assert.equal(mutator2.record.getCall(0).args[0], x);
+        assert.equal(mutator2.record.getCall(0).args[1], 'data');
+        assert.equal(mutator2.record.getCall(0).args[2], 'third');
+        assert.equal(mutator2.record.getCall(0).args[3], 'second');
+
+        Binder.popMutator(mutator2);
+        x.data = 'fourth';
+        assert.equal(mutator2.record.callCount, 1);
+        assert.equal(mutator1.record.callCount, 2);
+        assert.equal(mutator1.record.getCall(1).args[0], x);
+        assert.equal(mutator1.record.getCall(1).args[1], 'data');
+        assert.equal(mutator1.record.getCall(1).args[2], 'fourth');
+        assert.equal(mutator1.record.getCall(1).args[3], 'third');
+
+        Binder.popMutator(mutator1);
+        x.data = 'fifth';
+        assert.equal(mutator2.record.callCount, 1);
+        assert.equal(mutator1.record.callCount, 2);
+    });
+
+});

--- a/test/bindings/CollectionBinderTest.jsx
+++ b/test/bindings/CollectionBinderTest.jsx
@@ -1,0 +1,103 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import { CollectionBinder, TaskQueue, ObservableArray, ObservableSet, ObservableMap } from '../../index';
+import assert from 'assert';
+
+describe('Bindings.CollectionBinder', () => {
+
+    it('detect ObservableArray length change', () => {
+        let array = new ObservableArray;
+
+        let signaled = 0;
+
+        new CollectionBinder(() => array, (array) => {
+            assert.ok(array instanceof Array, 'The computed array should be a regular array.');
+            ++signaled;
+        });
+
+        assert.equal(signaled, 1, 'The binder callback should trigger.');
+
+        array.push('new item');
+        TaskQueue.run();
+
+        assert.equal(signaled, 2, 'The binder callback should trigger a second time after we push a new item.');
+
+    });
+
+    it('detect ObservableSet length change', () => {
+        let set = new ObservableSet;
+
+        let signaled = 0;
+
+        new CollectionBinder(() => set, (set) => {
+            assert.ok(set instanceof Set, 'The computed set should be a regular set.');
+            ++signaled;
+        });
+
+        assert.equal(signaled, 1, 'The binder callback should trigger.');
+
+        set.add('new item');
+        set.add('another item');
+        TaskQueue.run();
+
+        assert.equal(signaled, 2, 'The binder callback should trigger a second time after we add a new item.');
+
+        set.delete('new item');
+        TaskQueue.run();
+
+        assert.equal(signaled, 3, 'The binder callback should trigger a third time after we delete the new item.');
+
+        set.clear();
+        TaskQueue.run();
+
+        assert.equal(signaled, 4, 'The binder callback should trigger a fourth time after we clear the set.');
+    });
+
+    it('detect ObservableMap length change', () => {
+        let map = new ObservableMap;
+
+        let signaled = 0;
+
+        new CollectionBinder(() => map, (map) => {
+            assert.ok(map instanceof Map, 'The computed map should be a regular map.');
+            ++signaled;
+        });
+
+        assert.equal(signaled, 1, 'The binder callback should trigger.');
+
+        map.set('key', 'new item');
+        map.set('otherkey', 'another item');
+        TaskQueue.run();
+
+        assert.equal(signaled, 2, 'The binder callback should trigger a second time after we set a new item.');
+
+        map.set('otherkey', 'another item');
+        TaskQueue.run();
+
+        assert.equal(signaled, 2, 'The binder callback should NOT trigger on setting an item to its stored value.');
+
+        map.delete('otherkey');
+        TaskQueue.run();
+
+        assert.equal(signaled, 3, 'The binder callback should trigger a third time after we delete the new item.');
+
+        map.clear();
+        TaskQueue.run();
+
+        assert.equal(signaled, 4, 'The binder callback should trigger a fourth time after we clear the map.');
+    });
+
+});

--- a/test/bindings/FiltersTest.jsx
+++ b/test/bindings/FiltersTest.jsx
@@ -1,0 +1,132 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import { Signal, Binder, TaskQueue } from '../../index';
+import Filters from '../../src/internal/filters/Filters';
+import assert from 'assert';
+
+describe('Bindings.Filters', () => {
+
+    it('check for subscription support', (done) => {
+        class TorqSubscriptionBinding {
+
+            constructor(source) {
+                this._source = source;
+                this._refCount = 0;
+            }
+
+            _startSubscription() {
+                this._subscription = this._source.subscribe(this._push);
+            }
+
+            _stopSubscription() {
+                this._subscription.dispose();
+                this._subscription = null;
+            }
+
+            ref() {
+                if ((++this._refCount) === 1) {
+                    this._startSubscription();
+                }
+
+                // We are reusing the same object as the binding, so we need to conform with the API of the Binder.
+                // It is expecting us to have two properties: eventName and obj.
+                return {
+                    eventName: 'value',
+                    obj: this,
+                    dispose: this._deref
+                };
+            }
+
+            // Using task to avoid killing the subscription when the value doesn't really change.
+            // With task, we defer the actual stop until the frame is over. If any other binder happens to reach to this
+            // generator, we will reuse its subscription even if the previous binder was already disposed.
+            @Task
+            _deref() {
+                if ((--this._refCount) === 0) {
+                    this._stopSubscription();
+                }
+            }
+
+            @Bind
+            _push(value) {
+                this.value = value;
+                Signal.trigger(this, 'value');
+            }
+
+        }
+
+        let subscribtionDisposeCallCount = 0;
+
+        class Generator {
+
+            subscribe(cb) {
+                Signal.on(this, 'push', cb);
+                return {
+                    dispose: () => {
+                        ++subscribtionDisposeCallCount;
+                        Signal.off(this, 'push', cb);
+                    }
+                };
+            }
+
+            push(value) {
+                Signal.trigger(this, 'push', value);
+            }
+
+        }
+
+        function CustomFilter(bindings, value) {
+            if (value && (value instanceof Generator)) {
+                let binding = value._torq_binding;
+                if (!binding) {
+                    binding = value._torq_binding = new TorqSubscriptionBinding(value);
+                }
+                // Increment the ref count.
+                bindings.push(binding.ref());
+                return binding;
+            }
+        }
+
+        Filters.add(CustomFilter);
+
+        let generator = new Generator;
+
+        let binder = new Binder(() => generator);
+        assert.equal(binder.previousValue, undefined);
+
+        assert.equal(subscribtionDisposeCallCount, 0, 'The generator should not be disposed yet');
+
+        generator.push('second value');
+
+        // we need to wait until the promise queue runs.
+        Promise.resolve(true).then(() => {
+            TaskQueue.run();
+
+            assert.equal(subscribtionDisposeCallCount, 0, 'Even after the first read, the generator should not be disposed yet');
+            assert.equal(binder.previousValue, 'second value');
+
+            binder.dispose();
+            TaskQueue.run();
+
+            assert.equal(subscribtionDisposeCallCount, 1, 'The generator should be disposed by now');
+
+            Filters.remove(CustomFilter);
+
+            done();
+        }).catch(done);
+    });
+
+});

--- a/test/bindings/PromiseFilterTest.jsx
+++ b/test/bindings/PromiseFilterTest.jsx
@@ -1,0 +1,124 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import { Binder, TaskQueue } from '../../index';
+import assert from 'assert';
+
+class Deferred {
+    constructor() {
+        this.promise = new Promise((resolve, reject) => this._deferredApi = { resolve, reject });
+    }
+
+    resolve(value) {
+        this._deferredApi.resolve(value);
+    }
+
+    reject(value) {
+        this._deferredApi.reject(value);
+    }
+}
+
+
+describe('Bindings.PromiseFilter', () => {
+
+    it('check for promises', (done) => {
+        class X {
+            @Observable data;
+        }
+        let x = new X;
+        let signaled = 0;
+        let expectedValue = undefined;
+
+        let deferred = new Deferred;
+        x.data = deferred.promise;
+
+        new Binder(() => x.data, (value) => {
+            assert.equal(value, expectedValue);
+            ++signaled;
+        });
+
+        TaskQueue.run();
+        assert.equal(signaled, 1, 'The binder callback should trigger.');
+
+        expectedValue = 'first value';
+        deferred.resolve(expectedValue);
+
+        // we need to wait until the promise queue runs.
+        Promise.resolve(true).then(() => {
+            TaskQueue.run();
+            assert.equal(signaled, 2, 'The binder callback should trigger the second time.');
+
+            done();
+        }).catch(done);
+    });
+
+    it('check for promises in JSX', (done) => {
+        let deferred = new Deferred;
+
+        let test = new Binder(() => deferred.promise);
+        assert.equal(test.previousValue, undefined);
+
+        deferred.resolve('second value');
+
+        // we need to wait until the promise queue runs.
+        Promise.resolve(true).then(() => {
+            TaskQueue.run();
+
+            assert.equal(test.previousValue, 'second value');
+
+            test.dispose();
+            done();
+        }).catch(done);
+    });
+
+    it('check for pre-resolved promises in JSX', (done) => {
+        let promise = Promise.resolve('first value');
+
+        let test = new Binder(() => promise);
+
+        // We need to take a look at the value. The callback we pass to "then" is not going to resolve in the same callstack.
+        assert.equal(test.previousValue, undefined);
+
+        // We need to wait until the promise queue runs.
+        Promise.resolve(true).then(() => {
+            TaskQueue.run();
+
+            assert.equal(test.previousValue, 'first value');
+
+            test.dispose();
+            done();
+        }).catch(done);
+    });
+
+    it('check for rejected promises in JSX', (done) => {
+        let deferred = new Deferred;
+
+        let test = new Binder(() => deferred.promise);
+        assert.equal(test.previousValue, undefined);
+
+        deferred.reject(new Error('reasons'));
+
+        // we need to wait until the promise queue runs.
+        Promise.resolve(true).then(() => {
+            TaskQueue.run();
+
+            assert.equal(test.previousValue, undefined);
+
+            test.dispose();
+            done();
+        }).catch(done);
+    });
+
+});

--- a/test/bindings/SignalTest.jsx
+++ b/test/bindings/SignalTest.jsx
@@ -1,0 +1,196 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* global describe it */
+
+import { Signal } from '../../index';
+import assert from 'assert';
+
+describe('Bindings.Signal', () => {
+
+    it('trigger event', () => {
+        let obj = { };
+        let signaled = false;
+        Signal.on(obj, 'event1', () => {
+            signaled = true;
+        });
+        Signal.trigger(obj, 'event1');
+        assert.ok(signaled, 'The signal was triggered.');
+
+        // Adding this line to make sure we get full coverage for events that don't exist.
+        Signal.trigger(obj, 'event2');
+    });
+
+    it('owner is respected', () => {
+        let owner = {};
+        let signal = new Signal(owner);
+        let calledOwner;
+        signal.add(function() {
+            calledOwner = this;
+        });
+        signal.trigger();
+        assert.equal(calledOwner, owner);
+    });
+
+    it('adding two events', () => {
+        let obj = { };
+        let signaled1 = false, signaled2 = false;
+        Signal.on(obj, 'event1', () => signaled1 = true);
+        Signal.on(obj, 'event2', () => signaled2 = true);
+
+        Signal.trigger(obj, 'event1');
+        assert.ok(signaled1, 'The first signal was triggered.');
+
+        Signal.trigger(obj, 'event2');
+        assert.ok(signaled2, 'The second signal was triggered.');
+    });
+
+    it('removing event name before signals were initialized', () => {
+        // This test is needed to have full coverage for Signal.
+        let obj = { };
+        Signal.off(obj, 'event1', () => {
+            // noop;
+        });
+    });
+
+    it("removing event name that doesn't exist", () => {
+        // This test is needed to have full coverage for Signal.
+        let obj = { };
+        Signal.on(obj, 'event1', () => {
+            // noop;
+        });
+        Signal.off(obj, 'event2', () => {
+            // noop;
+        });
+    });
+
+    it('events are not enumerable', () => {
+        let obj = { };
+        let found = false;
+        Signal.on(obj, 'event1', () => {
+        });
+
+        for (let i in obj) {
+            assert(!i);
+            found = true;
+        }
+
+        assert.ok(!found, 'The event should not create any enumerable properties on the object.');
+    });
+
+    it('trigger event with arguments', () => {
+        let obj = { };
+        let value = null;
+        Signal.on(obj, 'event1', (...args) => {
+            value = args;
+        });
+
+        Signal.trigger(obj, 'event1', 'oneValue');
+        assert.deepEqual(value, [ 'oneValue' ], 'The signal was triggered.');
+    });
+
+
+    it('trigger should have no effect after removing event handler', () => {
+        let obj = { };
+        let signalCount = 0;
+        let handler = () => {
+            ++signalCount;
+        };
+
+        Signal.on(obj, 'event1', handler);
+        Signal.trigger(obj, 'event1');
+        assert.equal(signalCount, 1, 'The signal was triggered once.');
+
+        // Removing the handler for this event.
+        Signal.off(obj, 'event1', handler);
+
+        Signal.trigger(obj, 'event1');
+        assert.equal(signalCount, 1, 'The signal should not trigger second time.');
+    });
+
+    it('listenTo', () => {
+        let obj1 = { }, obj2 = { };
+        let signalCount = 0;
+        let handler = () => {
+            ++signalCount;
+        };
+
+        Signal.listenTo(obj1, obj2, 'event1', handler);
+        Signal.trigger(obj2, 'event1');
+        assert.equal(signalCount, 1, 'Should trigger the event once.');
+
+        Signal.stopListening(obj1, obj2);
+        Signal.trigger(obj2, 'event1');
+        assert.equal(signalCount, 1, 'Should not trigger the event second time.');
+    });
+
+    it('stopListening on empty object', () => {
+        let obj = {};
+        Signal.stopListening(obj);
+    });
+
+    it('stopListening with name matching', () => {
+        let obj1 = { }, obj2 = { };
+        let signalCount = 0;
+        let handler = () => {
+            ++signalCount;
+        };
+
+        Signal.listenTo(obj1, obj2, 'event1', handler);
+        Signal.trigger(obj2, 'event1');
+        assert.equal(signalCount, 1, 'Should trigger the event once.');
+
+        // Note we are bogusly removing obj3 to test that we preserve obj2.
+        Signal.stopListening(obj1, obj2, 'event1');
+        Signal.trigger(obj2, 'event1');
+        assert.equal(signalCount, 1, 'Should not trigger the event second time.');
+    });
+
+    it('stopListening with name and handler matching', () => {
+        let obj1 = { }, obj2 = { };
+        let signalCount = 0;
+        let handler = () => {
+            ++signalCount;
+        };
+
+        Signal.listenTo(obj1, obj2, 'event1', handler);
+        Signal.trigger(obj2, 'event1');
+        assert.equal(signalCount, 1, 'Should trigger the event once.');
+
+        // Note we are bogusly removing obj3 to test that we preserve obj2.
+        Signal.stopListening(obj1, obj2, 'event1', handler);
+        Signal.trigger(obj2, 'event1');
+        assert.equal(signalCount, 1, 'Should not trigger the event second time.');
+    });
+
+    it('stopListening with no matching callback', () => {
+        let obj1 = { }, obj2 = { }, obj3 = { };
+        let signalCount = 0;
+        let handler = () => {
+            ++signalCount;
+        };
+
+        Signal.listenTo(obj1, obj2, 'event1', handler);
+        Signal.trigger(obj2, 'event1');
+        assert.equal(signalCount, 1, 'Should trigger the event once.');
+
+        // Note we are bogusly removing obj3 to test that we preserve obj2.
+        Signal.stopListening(obj1, obj3);
+        Signal.trigger(obj2, 'event1');
+        assert.equal(signalCount, 2, 'Should trigger the event second time as well.');
+
+        Signal.trigger(obj3, 'event1');
+        assert.equal(signalCount, 2, 'Should not trigger on the event from obj3.');
+    });
+
+});

--- a/test/internal/utils/LoggerTest.jsx
+++ b/test/internal/utils/LoggerTest.jsx
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+/* eslint no-console: "off" */
+/* global describe it */
+
+import assert from 'assert';
+import sinon from 'sinon';
+import Logger from '../../../src/internal/utils/Logger';
+
+describe('Utils.Logger', () => {
+
+    it('Logger.log', () => {
+        sinon.spy(console, 'log');
+
+        Logger.log('Test1', 'Test2');
+        assert(console.log.calledWith('Test1', 'Test2'));
+
+        console.log.restore();
+    });
+
+    it('Logger.assert', () => {
+        sinon.spy(console, 'assert');
+
+        Logger.assert('Test1', 'Test2');
+        assert(console.assert.calledWith('Test1', 'Test2'));
+
+        console.assert.restore();
+    });
+
+    it('Logger.table', () => {
+        sinon.spy(console, 'table');
+
+        Logger.table('Test1', 'Test2');
+        assert(console.table.calledWith('Test1', 'Test2'));
+
+        console.table.restore();
+    });
+
+    it('Logger.groupStart', () => {
+        sinon.spy(console, 'group');
+
+        Logger.groupStart('Test1', 'Test2');
+        assert(console.group.calledWith('Test1', 'Test2'));
+
+        console.group.restore();
+    });
+
+    it('Logger.groupEnd', () => {
+        sinon.spy(console, 'groupEnd');
+
+        Logger.groupEnd('Test1', 'Test2');
+        assert(console.groupEnd.calledWith('Test1', 'Test2'));
+
+        console.groupEnd.restore();
+    });
+
+});


### PR DESCRIPTION
I think this covers all of the old tests that apply to this repository. The only notable changes, apart from imports, were replacing each `Test.jsx()` reference with a `Binder` instance.